### PR TITLE
Update discoveryapis_generator code to fix cast exception on null value

### DIFF
--- a/discoveryapis_generator/lib/src/dart_schemas.dart
+++ b/discoveryapis_generator/lib/src/dart_schemas.dart
@@ -842,10 +842,9 @@ class ObjectType extends ComplexDartSchemaType {
         // The super variant fromJson() will call this subclass constructor
         // and the variant descriminator is final.
         if (!isVariantDiscriminator(property)) {
-          final decodeString = property.type!
-              .jsonDecode("_json['${escapeString(property.jsonName)}']");
-          fromJsonString.writeln('    if (_json.containsKey'
-              "('${escapeString(property.jsonName)}')) {");
+          final propertyValue = "_json['${escapeString(property.jsonName)}']";
+          final decodeString = property.type!.jsonDecode(propertyValue);
+          fromJsonString.writeln('    if ($propertyValue != null) {');
           fromJsonString.writeln('      ${property.name} = $decodeString;');
           fromJsonString.writeln('    }');
         }


### PR DESCRIPTION
Update the code of the `discoveryapis_generator` to generate code that does not throw a cast exception when an API returns a property with an explicit null value (see [#211](https://github.com/google/googleapis.dart/issues/211)).